### PR TITLE
Support changes made when multiple fields rules match the target

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1012,43 +1012,47 @@ class JustValidate {
   }
 
   handleFieldChange = (target: HTMLInputElement): void => {
-    let foundKey;
+    const foundKeys: string[] = [];
 
     for (const key in this.fields) {
       const field = this.fields[key];
 
       if (field.elem === target) {
-        foundKey = key;
-        break;
+        foundKeys.push(key);
       }
     }
 
-    if (!foundKey) {
+    if (foundKeys.length === 0) {
       return;
     }
 
-    this.fields[foundKey].touched = true;
-    this.validateField(foundKey, true);
+    // Process each found key
+    foundKeys.forEach((key) => {
+      this.fields[key].touched = true;
+      this.validateField(key, true);
+    });
   };
 
   handleGroupChange = (target: HTMLInputElement): void => {
-    let foundKey;
+    const foundKeys: string[] = [];
 
     for (const key in this.groupFields) {
       const group = this.groupFields[key];
 
       if (group.elems.find((elem) => elem === target)) {
-        foundKey = key;
-        break;
+        foundKeys.push(key);
       }
     }
 
-    if (!foundKey) {
+    if (foundKeys.length === 0) {
       return;
     }
 
-    this.groupFields[foundKey].touched = true;
-    this.validateGroup(foundKey, true);
+    // Process each found key
+    foundKeys.forEach((key) => {
+      this.groupFields[key].touched = true;
+      this.validateGroup(key, true);
+    });
   };
 
   handlerChange = (ev: Event): void => {


### PR DESCRIPTION
In the case where multiple "fields" have been registered that may overlap, allow the validation logic to apply to targets that have been changed that match multiple rules (e.g. if addField('input[min]', ...) was registered separate from addField('input[max]', ...), but a form input potentially supports both)

I appreciate this may be slightly outside the intent of `addField` as I'm treating it conceptually a bit more like an `addRule` to a particular "category of fields", but it helped my use case when attempting to have lots of small pieces of generic reusable rules rather than handcrafting for a particular form quite so specifically.
