### PR TITLE
Fix: revalidate Method Focuses Field Instead of Showing Errors

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -926,7 +926,7 @@ class JustValidate {
   afterSubmitValidation(forceRevalidation = false): void {
     this.renderErrors(forceRevalidation);
 
-    if (this.globalConfig.focusInvalidField) {
+    if (this.globalConfig.focusInvalidField && !forceRevalidation) {
       this.focusInvalidField();
     }
   }
@@ -1822,11 +1822,11 @@ class JustValidate {
     this.isValid = true;
 
     for (const key in this.groupFields) {
-      this.renderGroupError(key);
+      this.renderGroupError(key, forceRevalidation);
     }
 
     for (const key in this.fields) {
-      this.renderFieldError(key);
+      this.renderFieldError(key, forceRevalidation);
     }
   }
 


### PR DESCRIPTION
## Problem

When calling `revalidate()`, the input field gets focused as expected, but **validation error messages are not displayed** unless the form is submitted. This creates confusion as the field appears active but without any visible feedback.

---

##  Steps to Reproduce

1. Initialize `JustValidate` with validation rules:

   ```js
   const validation = new JustValidate('#form');

   validation.addField('#email', [
     { rule: 'required', errorMessage: 'Email is required' },
     { rule: 'email', errorMessage: 'Invalid email format' },
   ]);

   validation.revalidate();

2. Call validation.revalidate().

3. The input field is focused, but no error message is shown, even if it's invalid.

## Expected Behavior
Calling revalidate() should trigger validation and display error messages immediately, without requiring form submission or additional interaction.

## Solution
Updated calls to renderGroupError and renderFieldError to pass the forceRevalidation parameter. This ensures that errors are rendered properly during revalidation, improving the consistency of validation feedback.